### PR TITLE
Set Language name and native_name from pycountry during creation

### DIFF
--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -10,3 +10,4 @@ tzf.pyramid-yml==1.1.0
 pyramid-basemodel==0.3.6
 pyramid_mako==1.0.2
 babel==2.3.4
+pycountry==1.20

--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,8 @@ requirements = [
     'pyramid_basemodel',
     'tzf.pyramid_yml >=0.2',
     'pyramid >=1.5a1',
-    'pyramid_mako'
+    'pyramid_mako',
+    'pycountry==1.20'
 ]
 
 test_requires = [

--- a/setup.py
+++ b/setup.py
@@ -17,8 +17,7 @@ requirements = [
     'pyramid_basemodel',
     'tzf.pyramid_yml >=0.2',
     'pyramid >=1.5a1',
-    'pyramid_mako',
-    'pycountry==1.20'
+    'pyramid_mako'
 ]
 
 test_requires = [

--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,8 @@ requirements = [
     'pyramid_basemodel',
     'tzf.pyramid_yml >=0.2',
     'pyramid >=1.5a1',
-    'pyramid_mako'
+    'pyramid_mako',
+    'pycountry'
 ]
 
 test_requires = [


### PR DESCRIPTION
As specified in #8, this adds an event listener that should automatically set the `name` and `native_name` attributes of a `Language` object during its creation using databases from pycountry.

In addition, if the language code is not valid/recognized, these values default to `UNKNOWN`.